### PR TITLE
[yamuisplash] Adapt to yamui changes. Fixes JB#59812

### DIFF
--- a/rpm/yamuisplash.spec
+++ b/rpm/yamuisplash.spec
@@ -7,7 +7,7 @@ License:	ASL 2.0
 Source0:	%{name}-%{version}.tar.gz
 
 Conflicts:	qmlsplash
-Requires:	yamui
+Requires:	yamui >= 1.2.0
 BuildRequires:	pkgconfig(systemd)
 
 %description
@@ -20,7 +20,6 @@ Yamuisplash is a simple splash screen for SailfishOS.
 # Nothing to do here
 
 %install
-install -D -m 744 yamuisplash $RPM_BUILD_ROOT%{_bindir}/yamuisplash
 install -D -m 644 logo/sailfish_logo_rgb.png $RPM_BUILD_ROOT%{_datarootdir}/%{name}/sailfish_logo_rgb.png
 install -D -m 644 systemd/yamuisplash.service $RPM_BUILD_ROOT%{_unitdir}/yamuisplash.service
 
@@ -30,12 +29,6 @@ ln -s ../yamuisplash.service $RPM_BUILD_ROOT%{_unitdir}/graphical.target.wants/y
 install -d $RPM_BUILD_ROOT/%{_unitdir}/system-update-pre.target.wants
 ln -s ../yamuisplash.service $RPM_BUILD_ROOT%{_unitdir}/system-update-pre.target.wants/yamuisplash.service
 
-install -d $RPM_BUILD_ROOT/%{_unitdir}/sailfish-unlock-agent.service.d
-cp systemd/01-yamuisplash.conf $RPM_BUILD_ROOT%{_unitdir}/sailfish-unlock-agent.service.d/
-
-install -d $RPM_BUILD_ROOT/%{_unitdir}/systemd-user-sessions.service.d
-cp systemd/01-yamuisplash.conf $RPM_BUILD_ROOT%{_unitdir}/systemd-user-sessions.service.d/
-
 %files
 %defattr(-,root,root,-)
 %license LICENSE-2.0.txt
@@ -43,6 +36,3 @@ cp systemd/01-yamuisplash.conf $RPM_BUILD_ROOT%{_unitdir}/systemd-user-sessions.
 %{_unitdir}/graphical.target.wants/%{name}.service
 %{_unitdir}/system-update-pre.target.wants/%{name}.service
 %{_datarootdir}/%{name}/sailfish_logo_rgb.png
-%{_unitdir}/sailfish-unlock-agent.service.d/01-yamuisplash.conf
-%{_unitdir}/systemd-user-sessions.service.d/01-yamuisplash.conf
-%{_bindir}/yamuisplash

--- a/systemd/01-yamuisplash.conf
+++ b/systemd/01-yamuisplash.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=/usr/bin/systemctl stop yamuisplash

--- a/systemd/yamuisplash.service
+++ b/systemd/yamuisplash.service
@@ -1,14 +1,18 @@
 [Unit]
 Description=Simple yamui splash screen for SailfishOS
-Before=droid-hal-init.service
-After=tmp.mount
+Before=sailfish-unlock-agent.service
+Before=start-user-session.service
 DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
 # To avoid starting again when swichting from emergency-call.target to graphical.target
-ConditionPathExists=!/tmp/.yamuisplash.done
+ConditionPathExists=!/run/yamuisplash/done
 
 [Service]
-Type=simple
+Type=notify
+Restart=no
 EnvironmentFile=-/var/lib/environment/compositor/*.conf
-ExecStart=/bin/sh /usr/bin/yamuisplash
-# make sure we run for at least 5 seconds for any touch initialization sequences to finish.
-ExecStartPost=/bin/sleep 5
+ExecStartPre=/bin/touch /run/yamuisplash/done
+ExecStart=/usr/bin/yamui --systemd /usr/share/yamuisplash/sailfish_logo_rgb.png
+RuntimeDirectory=yamuisplash
+RuntimeDirectoryPreserve=yes

--- a/yamuisplash
+++ b/yamuisplash
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-touch /tmp/.yamuisplash.done
-exec yamui --imagesdir=/usr/share/yamuisplash sailfish_logo_rgb


### PR DESCRIPTION
Yamui has been modified so that it is systemd aware and implements compositor D-Bus service.

Switch yamuisplash systemd service type from simple to notify, and remove the not really necessary start script.

As yamui will now automatically exit when the next UI wants to take over display, systemd drop-ins that were used for explicitly stopping splashscreen service can be removed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>